### PR TITLE
Use initialCount as initialValue (update 06.md)

### DIFF
--- a/src/exercise/06.md
+++ b/src/exercise/06.md
@@ -17,7 +17,7 @@ call it like so:
 ```javascript
 function useCount({initialCount = 0, step = 1} = {}) {
   React.useDebugValue({initialCount, step})
-  const [count, setCount] = React.useState(0)
+  const [count, setCount] = React.useState(initialCount)
   const increment = () => setCount(c => c + step)
   return [count, increment]
 }


### PR DESCRIPTION
Hi Kent, I think you meant to use `initialCount` as the initial value for the count state here since you are setting it as default value on the props.