### PR TITLE
Add caching talk to 03.custom-hooks intro

### DIFF
--- a/exercises/03.custom-hooks/README.mdx
+++ b/exercises/03.custom-hooks/README.mdx
@@ -198,6 +198,8 @@ There's a strategy to help you avoid dependency arrays talked about in
 Additionally, there's a pattern you can use to help reduce the issue (with its
 own set of trade-offs) which we'll explore in the React Patterns workshop.
 
+🦉 Better understand memoization by diving deep on caching with my talk [Caching for Cash](https://www.epicweb.dev/talks/caching-for-cash).
+
 🦉 A common question with this is: "Why don't we just wrap every function in
 `useCallback`?" You can read about this in my blog post
 [When to useMemo and useCallback](https://kentcdodds.com/blog/usememo-and-usecallback).
@@ -205,3 +207,5 @@ own set of trade-offs) which we'll explore in the React Patterns workshop.
 🦉 And if the concept of a "closure" is new or confusing to you, then
 [give this a read](https://mdn.io/closure). (Closures are one of the reasons
 it's important to keep dependency lists correct.)
+
+


### PR DESCRIPTION
I'm still not quite clear on the exact distinction between 🦉 and 📜 but went with 🦉 because the other two bullets that are similar did.

![gif](https://media1.giphy.com/media/dmlozGjvGf5IY/giphy.gif?cid=1927fc1b0a0ob1dnchwy07fy600nwe9m5rvbd3pp69b0wrmv&ep=v1_gifs_search&rid=giphy.gif&ct=g)